### PR TITLE
Pia 1127

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -3,8 +3,8 @@ PODS:
   - GiniCapture/Networking (1.0.2):
     - GiniCapture/Core
     - GiniPayApiLib/DocumentsAPI (>= 1.0.2)
-  - GiniPayApiLib/DocumentsAPI (1.0.6)
-  - GiniPayApiLib/Pinning (1.0.6):
+  - GiniPayApiLib/DocumentsAPI (1.0.7)
+  - GiniPayApiLib/Pinning (1.0.7):
     - GiniPayApiLib/DocumentsAPI
     - TrustKit (~> 1.6)
   - GiniPayBank (0.0.2):
@@ -33,7 +33,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   GiniCapture: 2a18e6714d0073dd754a74784558fcdfc791fdd5
-  GiniPayApiLib: 6e47f461db91fd1ede8d7212c92dddd6a7707118
+  GiniPayApiLib: 2729b758c086a0801d9b9e53a9c33981ef303612
   GiniPayBank: f0ad0c4ac54653f9535788e3cf491c67cfaa014c
   TrustKit: 073855e3adecd317417bda4ac9e9ac54a2e3b9f2
 

--- a/GiniPayBank/Classes/Core/GiniPayBank.swift
+++ b/GiniPayBank/Classes/Core/GiniPayBank.swift
@@ -56,17 +56,17 @@ import GiniPayApiLib
      - parameter paymentRequesId: Id of payment request.
      - parameter completion: An action for processing asynchronous data received from the service with Result type as a paramater. Result is a value that represents either a success or a failure, including an associated value in each case.
      Completion block called on main thread.
-     In success returns the payment structure.
+     In success returns the resolved payment request structure.
      In case of failure error from the server side.
 
      */
-    public func resolvePaymentRequest(paymentRequesId: String, paymentInfo: PaymentInfo, completion: @escaping (Result<String, GiniPayBankError>) -> Void) {
+    public func resolvePaymentRequest(paymentRequesId: String, paymentInfo: PaymentInfo, completion: @escaping (Result<ResolvedPaymentRequest, GiniPayBankError>) -> Void) {
 
         paymentService.resolvePaymentRequest(id: paymentRequesId, recipient: paymentInfo.recipient, iban: paymentInfo.iban, amount: paymentInfo.amount, purpose: paymentInfo.purpose, completion: { result in
             DispatchQueue.main.async {
                 switch result {
-                case let .success(payment):
-                    completion(.success(payment))
+                case let .success(resolvedPayment):
+                    completion(.success(resolvedPayment))
                 case let .failure(error):
                     completion(.failure(.apiError(error)))
                 }
@@ -77,11 +77,12 @@ import GiniPayApiLib
 
     /**
      Returns back to the business app.
-     Return button should be active for the user after resolving the payment request.
+     
+     - parameter resolvedPaymentRequest: resolved payment request returned by method 'resolvePaymentRequest'
 
      */
-    public func returnBackToBusinessAppHandler(paymentRequesterScheme: String) {
-        if let resultUrl = URL(string: paymentRequesterScheme) {
+    public func returnBackToBusinessAppHandler(resolvedPaymentRequest: ResolvedPaymentRequest) {
+        if let resultUrl = URL(string: resolvedPaymentRequest.requesterUri) {
             DispatchQueue.main.async {
                 UIApplication.shared.open(resultUrl, options: [:], completionHandler: nil)
             }


### PR DESCRIPTION
GiniPayBank:
* resolvePaymentRequest in success case returns the resolved payment request structure;
* returnBackToBusinessAppHandler takes the resolved payment request structure as a parameter. (PIA-1127)
Example Bank: updated the view model:
* removed var requesterAppScheme, instead used private var paymentRequest;
* openPaymentRequesterApp picked paymentRequest as a parameter. (PIA-1127)
* To run example pod update and add credentials