### PR TITLE
Feature/pia 1401 use total amount from extractions

### DIFF
--- a/GiniPayBank/Classes/Core/ReturnAssistant/DigitalInvoice.swift
+++ b/GiniPayBank/Classes/Core/ReturnAssistant/DigitalInvoice.swift
@@ -35,6 +35,13 @@ public struct DigitalInvoice {
             }
         }
         
+        let lineItemsTotalPriceDiffs = lineItems.reduce(Price(value: 0, currencyCode: firstLineItem.price.currencyCode)) { (current, lineItem) -> Price? in
+            
+            guard let current = current else { return nil }
+            
+            return try? current + lineItem.totalPriceDiff
+        }
+        
         let userAddedLineItemsTotalPrice = lineItems.reduce(Price(value: 0, currencyCode: firstLineItem.price.currencyCode)) { (current, lineItem) -> Price? in
             
             guard let current = current else { return nil }
@@ -47,8 +54,12 @@ public struct DigitalInvoice {
         }
         
         if let deselectedLineItemsTotalPrice = deselectedLineItemsTotalPrice,
-            let userAddedLineItemsTotalPrice = userAddedLineItemsTotalPrice {
-            return try? Price.max(amountToPay - deselectedLineItemsTotalPrice + userAddedLineItemsTotalPrice,
+            let userAddedLineItemsTotalPrice = userAddedLineItemsTotalPrice,
+            let lineItemsTotalPriceDiffs = lineItemsTotalPriceDiffs {
+            return try? Price.max(amountToPay
+                                    - deselectedLineItemsTotalPrice
+                                    + lineItemsTotalPriceDiffs
+                                    + userAddedLineItemsTotalPrice,
                                          Price(value: 0, currencyCode: firstLineItem.price.currencyCode))
         } else {
             return amountToPay

--- a/GiniPayBank/Classes/Core/ReturnAssistant/LineItem.swift
+++ b/GiniPayBank/Classes/Core/ReturnAssistant/LineItem.swift
@@ -23,6 +23,9 @@ extension DigitalInvoice {
         var selectedState: SelectedState
         var isUserInitiated = false
         
+        private let origPrice: Price
+        private let origQuantity: Int
+        
         private enum ExtractedLineItemKey: String {
             case description, quantity, baseGross
         }
@@ -30,7 +33,9 @@ extension DigitalInvoice {
         init(name: String?, quantity: Int, price: Price, selectedState: SelectedState, isUserInitiated: Bool = false) {
             self.name = name
             self.quantity = quantity
+            self.origQuantity = quantity
             self.price = price
+            self.origPrice = price
             self.selectedState = selectedState
             self._extractions = []
             self.isUserInitiated = isUserInitiated
@@ -61,7 +66,9 @@ extension DigitalInvoice {
             self._extractions = extractions
             self.name = extractedName
             self.quantity = quantity
+            self.origQuantity = quantity
             self.price = price
+            self.origPrice = price
             self.selectedState = .selected
         }
         
@@ -108,6 +115,10 @@ extension DigitalInvoice {
         
         var totalPrice: Price {
             return price * quantity
+        }
+        
+        var totalPriceDiff: Price {
+            return (try? totalPrice - (origPrice * origQuantity)) ?? Price(value: 0, currencyCode: totalPrice.currencyCode)
         }
     }
 }

--- a/GiniPayBank/Classes/Core/ReturnAssistant/Price.swift
+++ b/GiniPayBank/Classes/Core/ReturnAssistant/Price.swift
@@ -88,6 +88,16 @@ extension Price {
                      currencyCode: lhs.currencyCode)
     }
     
+    static func -(lhs: Price, rhs: Price) throws -> Price {
+        
+        if lhs.currencyCode != rhs.currencyCode {
+            throw PriceCurrencyMismatchError()
+        }
+        
+        return Price(value: lhs.value - rhs.value,
+                     currencyCode: lhs.currencyCode)
+    }
+    
     static func max(_ lhs: Price, _ rhs: Price) -> Price {
         return lhs.value >= rhs.value ? lhs : rhs
     }


### PR DESCRIPTION
Use `amountToPay` extraction to calculate the digital invoice total price.

Reflect line item price changes in the total price.