### PR TITLE
Calculate price diffs only for extracted line items

### DIFF
--- a/GiniPayBank/Classes/Core/ReturnAssistant/DigitalInvoice.swift
+++ b/GiniPayBank/Classes/Core/ReturnAssistant/DigitalInvoice.swift
@@ -39,7 +39,11 @@ public struct DigitalInvoice {
             
             guard let current = current else { return nil }
             
-            return try? current + lineItem.totalPriceDiff
+            if !lineItem.isUserInitiated {
+                return try? current + lineItem.totalPriceDiff
+            } else {
+                return current
+            }
         }
         
         let userAddedLineItemsTotalPrice = lineItems.reduce(Price(value: 0, currencyCode: firstLineItem.price.currencyCode)) { (current, lineItem) -> Price? in


### PR DESCRIPTION
User added line items need to be excluded from the price diff,
otherwise their price is added twice since their price diff is the
same as their price (orig price is 0 so orig - current = current).